### PR TITLE
Add support for submenu

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -51,9 +51,9 @@ class Menu extends CliMenuBuilder
     /**
      * Adds a new option.
      *
-     * @param mixed $value
-     * @param string $label
-     * @param CliMenuBuilder|null $subMenu
+     * @param  mixed  $value
+     * @param  string  $label
+     * @param  CliMenuBuilder|null  $subMenu
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
     public function addOption($value, string $label, ?CliMenuBuilder $subMenu = null): Menu
@@ -76,8 +76,8 @@ class Menu extends CliMenuBuilder
     /**
      * Adds multiple options.
      *
-     * @param array $options
-     * @param CliMenuBuilder|null $subMenu
+     * @param  array  $options
+     * @param  CliMenuBuilder|null  $subMenu
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
     public function addOptions(array $options, ?CliMenuBuilder $subMenu = null): Menu

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -86,10 +86,11 @@ class Menu extends CliMenuBuilder
     {
         foreach ($options as $value => $label) {
             if (is_array($label)) {
+                $subMenuOptions = $label;
                 $menu = $this;
-                $this->addSubMenu($value, function (CliMenuBuilder $b) use ($value, $label, $menu) {
-                    $b->setTitle($value);
-                    $menu->addOptions($label, $b);
+                $this->addSubMenu($value, function (CliMenuBuilder $subMenu) use ($value, $subMenuOptions, $menu) {
+                    $subMenu->setTitle($value);
+                    $menu->addOptions($subMenuOptions, $subMenu);
                 });
             } else {
                 $this->addOption($value, $label, $subMenu);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -54,11 +54,13 @@ class Menu extends CliMenuBuilder
      * @param mixed $value
      * @param string $label
      *
+     * @param CliMenuBuilder|null $subMenu
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
-    public function addOption($value, string $label): Menu
+    public function addOption($value, string $label, ?CliMenuBuilder $subMenu = null): Menu
     {
-        $this->addMenuItem(
+        $menu = $subMenu ?? $this;
+        $menu->addMenuItem(
             new MenuOption(
                 $value,
                 $label,
@@ -77,12 +79,21 @@ class Menu extends CliMenuBuilder
      *
      * @param array $options
      *
+     * @param CliMenuBuilder|null $subMenu
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
-    public function addOptions(array $options): Menu
+    public function addOptions(array $options, ?CliMenuBuilder $subMenu = null): Menu
     {
         foreach ($options as $value => $label) {
-            $this->addOption($value, $label);
+            if (is_array($label)) {
+                $menu = $this;
+                $this->addSubMenu($value, function (CliMenuBuilder $b) use ($value, $label, $menu) {
+                    $b->setTitle($value);
+                    $menu->addOptions($label, $b);
+                });
+            } else {
+                $this->addOption($value, $label, $subMenu);
+            }
         }
 
         return $this;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -54,7 +54,6 @@ class Menu extends CliMenuBuilder
      * @param mixed $value
      * @param string $label
      * @param CliMenuBuilder|null $subMenu
-     *
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
     public function addOption($value, string $label, ?CliMenuBuilder $subMenu = null): Menu
@@ -79,7 +78,6 @@ class Menu extends CliMenuBuilder
      *
      * @param array $options
      * @param CliMenuBuilder|null $subMenu
-     *
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
     public function addOptions(array $options, ?CliMenuBuilder $subMenu = null): Menu

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -54,11 +54,13 @@ class Menu extends CliMenuBuilder
      * @param mixed $value
      * @param string $label
      *
+     * @param CliMenuBuilder|null $subMenu
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
-    public function addOption($value, string $label): Menu
+    public function addOption($value, string $label, ?CliMenuBuilder $subMenu = null): Menu
     {
-        $this->addMenuItem(
+        $menu = $subMenu ?? $this;
+        $menu->addMenuItem(
             new MenuOption(
                 $value,
                 $label,
@@ -77,18 +79,20 @@ class Menu extends CliMenuBuilder
      *
      * @param array $options
      *
+     * @param CliMenuBuilder|null $subMenu
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
-    public function addOptions(array $options): Menu
+    public function addOptions(array $options, ?CliMenuBuilder $subMenu = null): Menu
     {
         foreach ($options as $value => $label) {
             if (is_array($label)) {
+                $menu = $this;
                 $this->addSubMenu($value, function (CliMenuBuilder $b) use ($value, $label, $menu) {
                     $b->setTitle($value);
                     $menu->addOptions($label, $b);
                 });
             } else {
-                $this->addOption($value, $label);
+                $this->addOption($value, $label, $subMenu);
             }
         }
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -54,13 +54,11 @@ class Menu extends CliMenuBuilder
      * @param mixed $value
      * @param string $label
      *
-     * @param CliMenuBuilder|null $subMenu
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
-    public function addOption($value, string $label, ?CliMenuBuilder $subMenu = null): Menu
+    public function addOption($value, string $label): Menu
     {
-        $menu = $subMenu ?? $this;
-        $menu->addMenuItem(
+        $this->addMenuItem(
             new MenuOption(
                 $value,
                 $label,
@@ -79,20 +77,18 @@ class Menu extends CliMenuBuilder
      *
      * @param array $options
      *
-     * @param CliMenuBuilder|null $subMenu
      * @return \NunoMaduro\LaravelConsoleMenu\Menu
      */
-    public function addOptions(array $options, ?CliMenuBuilder $subMenu = null): Menu
+    public function addOptions(array $options): Menu
     {
         foreach ($options as $value => $label) {
             if (is_array($label)) {
-                $menu = $this;
                 $this->addSubMenu($value, function (CliMenuBuilder $b) use ($value, $label, $menu) {
                     $b->setTitle($value);
                     $menu->addOptions($label, $b);
                 });
             } else {
-                $this->addOption($value, $label, $subMenu);
+                $this->addOption($value, $label);
             }
         }
 


### PR DESCRIPTION
Using the proposed change, we can add a submenu by making a multi-dimensional array;

```
$options = [
    'House' => [
        123 => 'Task 1',
        124 => 'Task 2',
        125 => 'Task 3',
        126 => 'Task 4',
    ],
    'Car' => [
        200 => 'Task 5',
        201 => 'Task 6',
        202 => 'Task 7',
        203 => 'Task 8',
    ]
];

$taskId = $this->menu('Select task from category', $options)->open();

dd($taskId);
```

![image](https://user-images.githubusercontent.com/431360/75218541-d34f6f80-579a-11ea-9f19-cc50fc96991d.png)

![image](https://user-images.githubusercontent.com/431360/75218553-da767d80-579a-11ea-91c1-9e2798b062b5.png)

![image](https://user-images.githubusercontent.com/431360/75218593-eb26f380-579a-11ea-987d-bd32109dee79.png)
